### PR TITLE
Count number of queries that can be relaxed

### DIFF
--- a/llvm/lib/Analysis/AliasAnalysis.cpp
+++ b/llvm/lib/Analysis/AliasAnalysis.cpp
@@ -308,7 +308,9 @@ AAInstrumentation *getAAInstrumentation() {
   return &AARelaxation;
 }
 
-STATISTIC(NumberOfRelaxableAAQueries, "Number of relaxable AA queries");
+STATISTIC(NumberOfRelaxationCandidates,
+          "Number of queries that are not cached and not MayAlias. Therefore, "
+          "these are candidates to be relaxed.");
 
 // Count the number of AA queries that have occured so far.
 static int CurrAAIndex = 0;
@@ -334,7 +336,7 @@ AliasResult relaxSpecificAliasResult(const llvm::Value *Ptr1,
     return Result;
   }
 
-  NumberOfRelaxableAAQueries++;
+  NumberOfRelaxationCandidates++;
 
   if (AAInstrumentation->isAAIndexToRelax(CurrAAIndex)) {
     CurrAAIndex++;

--- a/llvm/lib/Analysis/AliasAnalysis.cpp
+++ b/llvm/lib/Analysis/AliasAnalysis.cpp
@@ -308,6 +308,8 @@ AAInstrumentation *getAAInstrumentation() {
   return &AARelaxation;
 }
 
+STATISTIC(NumberOfRelaxableAAQueries, "Number of relaxable AA queries");
+
 // Count the number of AA queries that have occured so far.
 static int CurrAAIndex = 0;
 
@@ -331,6 +333,8 @@ AliasResult relaxSpecificAliasResult(const llvm::Value *Ptr1,
     }
     return Result;
   }
+
+  NumberOfRelaxableAAQueries++;
 
   if (AAInstrumentation->isAAIndexToRelax(CurrAAIndex)) {
     CurrAAIndex++;


### PR DESCRIPTION
This makes it s.t. using the -stats flag, one can figure out how many AA Queries can be relaxed. This is useful for several things, firstly, to figure out how long instrumentation sequences can be in the first place, as well as fixing the unique hashes plot.